### PR TITLE
feat: 添加「是否显示快捷键盘」选项

### DIFF
--- a/src/components/HomeworkEditDialog.vue
+++ b/src/components/HomeworkEditDialog.vue
@@ -102,7 +102,7 @@
           </div>
 
           <!-- Quick Tools Section -->
-          <div class="quick-tools ml-4" style="min-width: 180px;">
+          <div class="quick-tools ml-4" style="min-width: 180px;" v-if="showQuickTools">
             <!-- Numeric Keypad -->
             <div class="numeric-keypad mb-4">
               <div class="keypad-row">
@@ -207,6 +207,7 @@
 
 <script>
 import dataProvider from "@/utils/dataProvider";
+import { getSetting } from "@/utils/settings";
 
 export default {
   name: "HomeworkEditDialog",
@@ -270,6 +271,9 @@ export default {
         return null;
       }
       return this.templateData.commonSubject.books;
+    },
+    showQuickTools() {
+      return getSetting("display.showQuickTools");
     }
   },
   watch: {

--- a/src/components/HomeworkEditDialog.vue
+++ b/src/components/HomeworkEditDialog.vue
@@ -201,6 +201,11 @@
           </div>
         </div>
       </v-card-text>
+
+      <div class="text-center text-body-2 text-disabled mb-5">
+        点击空白处完成编辑
+      </div>
+
     </v-card>
   </v-dialog>
 </template>

--- a/src/components/settings/cards/DisplaySettingsCard.vue
+++ b/src/components/settings/cards/DisplaySettingsCard.vue
@@ -20,6 +20,9 @@
         <setting-item :setting-key="'display.enhancedTouchMode'" />
 
         <v-divider class="my-2" />
+        <setting-item :setting-key="'display.showQuickTools'" />
+
+        <v-divider class="my-2" />
         <setting-item :setting-key="'display.showAntiScreenBurnCard'" />
 
         <v-divider class="my-2" />

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -177,6 +177,12 @@ const settingsDefinitions = {
     icon: "mdi-calendar-check",
     // 控制是否在主页显示考试看板按钮，指向考试安排页面
   },
+  "display.showQuickTools": {
+    type: "boolean",
+    default: true,
+    description: "是否显示快捷键盘",
+    icon: "mdi-dialpad",
+  },
   // 服务器设置（合并了数据提供者设置）
   "server.domain": {
     type: "string",


### PR DESCRIPTION
feat: 添加「是否显示快捷键盘」选项

添加了 `display.showQuickTools` 设置项，控制是否在编辑作业时显示 `Quick Tools Section`。默认值为显示。

---

feat: 添加「点击空白处完成编辑」提示

在作业编辑 dialog 中下方添加了「点击空白处完成编辑」字样。未添加关闭选项。