### PR TITLE
fix: 调整一言默认数据源为诏预 (Zhaoyu) 并增加内容安全提示

### DIFF
--- a/src/components/HitokotoCard.vue
+++ b/src/components/HitokotoCard.vue
@@ -32,7 +32,7 @@ export default {
       enabled: false,
       refreshInterval: 60,
       kvConfig: {
-        sources: ['hitokoto'],
+        sources: ['zhaoyu'],
         sensitiveWords: []
       },
       sentence: '',
@@ -76,7 +76,7 @@ export default {
 
         if (data) {
           this.kvConfig = {
-            sources: Array.isArray(data.sources) && data.sources.length > 0 ? data.sources : ['hitokoto'],
+            sources: Array.isArray(data.sources) && data.sources.length > 0 ? data.sources : ['zhaoyu'],
             sensitiveWords: data.sensitiveWords ? data.sensitiveWords.split(/[,，]/).map(w => w.trim()).filter(w => w) : [],
             jinrishiciToken: data.jinrishiciToken
           }

--- a/src/components/HitokotoSettings.vue
+++ b/src/components/HitokotoSettings.vue
@@ -41,6 +41,10 @@
             @update:model-value="saveKvSettings"
           />
         </div>
+        <div class="text-caption text-orange mt-2">
+          <v-icon size="x-small" color="orange" class="mr-1">mdi-alert</v-icon>
+          一言（Hitokoto）数据源已收到关于存在负面内容的大量反馈，请用户谨慎启用。
+        </div>
       </v-list-item>
 
       <v-list-item v-if="kvConfig.sources.includes('jinrishici')">
@@ -94,7 +98,7 @@ export default {
   data() {
     return {
       kvConfig: {
-        sources: ['hitokoto'],
+        sources: ['zhaoyu'],
         sensitiveWords: '',
         jinrishiciToken: null
       },
@@ -116,7 +120,7 @@ export default {
 
         if (data) {
           this.kvConfig = {
-            sources: Array.isArray(data.sources) ? data.sources : ['hitokoto'],
+            sources: Array.isArray(data.sources) ? data.sources : ['zhaoyu'],
             sensitiveWords: data.sensitiveWords || '',
             jinrishiciToken: data.jinrishiciToken
           }


### PR DESCRIPTION
提交这个 PR 主要是为了优化“一言”功能在教学场景下的适用性，尽量减少负面内容出现的风险。

### 修改原因 / Motivation
在使用过程中发现，原默认数据源 **Hitokoto** 偶尔会返回一些带有负面情绪或消极、性暗示色彩的句子（如胸、巨乳等）。作为班级大屏展示工具，这类内容可能绝不适合在教室环境中长期展示。如图：
![图例](https://github.com/user-attachments/assets/da488400-d891-48f2-8f7f-f95986389c83)

### 主要改动 / Changes
为了改善这个问题，我使用Gemini Pro 3.0对相关组件做了以下调整：

1.  **更改默认源**：
    * 将 `HitokotoCard.vue` 和 `HitokotoSettings.vue` 中的默认数据源从 `hitokoto` 修改为 **诏预 (Zhaoyu)**。
    * 诏预源的内容相对更加稳重、积极，更贴合教学生产环境。

2.  **增加安全提示**：
    * 在 `HitokotoSettings.vue` 的设置面板中，为 Hitokoto 选项下方添加了一行橙色的 **警告提示**。
    * 提示文案为：“*Hitokoto数据源已收到大量反馈存在负面内容，请用户谨慎启用。*”

### 说明
- **请作者务必检查代码**。受条件所限，没有进行实际测试。十分感谢。